### PR TITLE
Add crowdloan stats display for mobile users

### DIFF
--- a/components/crowdloan-teaser/crowdloan-stats.tsx
+++ b/components/crowdloan-teaser/crowdloan-stats.tsx
@@ -1,4 +1,5 @@
 import { Button } from '../button/button';
+import { Link } from '../link/link';
 import { ProgressBar } from '../progressbar/progressbar';
 import { useCrowdloanStats } from './useCrowdloanStats';
 
@@ -33,8 +34,16 @@ export const CrowdloanStats = ({ onButtonClick }: CrowdloanStatsProps) => {
       </div>
 
       {/* Button to contribute */}
-      <div className="p-8">
+      <div className="hidden md:block p-8">
         <Button onClick={onButtonClick}>Contribute</Button>
+      </div>
+
+      <div className="block md:hidden p-8 ">
+        <p>
+          Our crowdloan UI is currently not available on a mobile phones. To contribute, please use
+          desktop browser with{' '}
+          <Link href="https://polkadot.js.org/extension/">{`Polkadot.{js}`} extension.</Link>
+        </p>
       </div>
     </div>
   );

--- a/components/link/link.tsx
+++ b/components/link/link.tsx
@@ -7,7 +7,7 @@ type LinkProps = {
 };
 
 export function Link({ href, children, className = '' }: LinkProps) {
-  const linksClassName = `${className} font-semibold underline decoration-primary hover:bg-primary`;
+  const linksClassName = `${className} underline decoration-primary hover:bg-primary hover:text-white`;
 
   // use next/link for internal links
   if (href.startsWith('/')) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,10 +27,8 @@ const Home: NextPage = () => {
               </p>
             </div>
           </div>
-          <div className="hidden md:block">
-            <div>
-              <CrowdloanTeaserLive />
-            </div>
+          <div className="block">
+            <CrowdloanTeaserLive />
           </div>
         </div>
         <div className="lg:py-8">


### PR DESCRIPTION
Currently we're hiding the stats about the crowdloan for users on small screen devices (most likely mobile users).
This PR changes the behavior so that:

- We're now displaying the crowdloan stats widget
- We'll be showing info to use deskto browsers (sorry 🤷) 